### PR TITLE
Feature: Cull Particles Based on Time

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export default class ParticleSystem implements IParticleSystem {
     // cull old particles
     const timeThreshold = Date.now() - this.particleLifetime;
     for (let i = 0; i < this.particleQueue.length; i++) {
-      if (this.particleQueue[i][0] > timeThreshold) {
+      if (this.particleQueue[i][0] < timeThreshold) {
         const removed = this.particleQueue.splice(0, i);
         this.removeParticles(removed);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,8 @@ export default class ParticleSystem implements IParticleSystem {
     const timeThreshold = Date.now() - this.particleLifetime;
     for (let i = 0; i < this.particleQueue.length; i++) {
       if (this.particleQueue[i][0] > timeThreshold) {
-        this.removeParticles(this.particleQueue.splice(0, i));
+        const removed = this.particleQueue.splice(0, i);
+        this.removeParticles(removed);
       }
     }
 
@@ -98,7 +99,7 @@ export default class ParticleSystem implements IParticleSystem {
     const overThreshold: number = this.particleQueue.length - this.maxParticles;
     if (overThreshold > 0) {
       const removed = this.particleQueue.splice(0, overThreshold);
-      removed.forEach(([timestamp, mesh]: particleTuple) => this.target.remove(mesh));
+      this.removeParticles(removed);
     }
 
     // update current particles

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export default class ParticleSystem implements IParticleSystem {
   shape: IShape = new PlaneShape();
   target: Object3D;
 
-  particleQueue: Array<particleTuple> = [];
+  private particleQueue: particleTuple[] = [];
   isPlaying: boolean = true;
   elapsedTime: number = 0;
   startTime: number;
@@ -65,7 +65,7 @@ export default class ParticleSystem implements IParticleSystem {
     newParticle.rotation.z = randomBoundedFloat(this.initialRotationRange[0].z, this.initialRotationRange[1].z);
 
     this.target.add(newParticle);
-    this.particleQueue.push(newParticle);
+    this.particleQueue.push([Date.now(), newParticle]);
   }
 
   removeParticles(particles: particleTuple[]): void {
@@ -120,7 +120,7 @@ export default class ParticleSystem implements IParticleSystem {
   }
 
   clear(): void {
-    this.target.remove(...this.particleQueue);
+    this.removeParticles(this.particleQueue);
     this.particleQueue = [];
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,8 @@ export default class ParticleSystem implements IParticleSystem {
   shape: IShape = new PlaneShape();
   target: Object3D;
 
-  private particleQueue: particleTuple[] = [];
+  particleQueue: particleTuple[] = [];
+  duration: number = 2000; // in MS
   isPlaying: boolean = true;
   elapsedTime: number = 0;
   startTime: number;
@@ -41,6 +42,7 @@ export default class ParticleSystem implements IParticleSystem {
     this.particlesPerSecond = options.particlesPerSecond || this.particlesPerSecond;
     this.particleVelocity = options.particleVelocity || this.particleVelocity;
     this.loop = isBool(options.loop) ? options.playOnLoad || false : this.loop;
+    this.duration = options.duration || this.duration;
     this.isPlaying = isBool(options.playOnLoad) ? options.playOnLoad || false : this.isPlaying;
     this.radius = options.radius || this.radius;
     this.rotationRate = options.rotationRate || this.rotationRate;
@@ -76,21 +78,24 @@ export default class ParticleSystem implements IParticleSystem {
 
   update(deltaTime: number = 0.02 /* 50fps */): void {
     if (!this.isPlaying) return;
-    if (!this.loop && this.elapsedTime > this.particleLifetime) {
+    if (!this.loop && this.elapsedTime > this.duration && !this.particleQueue.length) {
+      // No more particles being produced
       this.stop();
       return;
     }
 
     // create new particles
-    for (let i = 0; i < this.particlesPerSecond * deltaTime; i++) {
-      this.createPaticle();
+    if (this.loop || this.elapsedTime < this.duration) {
+      for (let i = 0; i < this.particlesPerSecond * deltaTime; i++) {
+        this.createPaticle();
+      }
     }
 
     // cull old particles
     const timeThreshold = Date.now() - this.particleLifetime;
     for (let i = 0; i < this.particleQueue.length; i++) {
       if (this.particleQueue[i][0] < timeThreshold) {
-        const removed = this.particleQueue.splice(0, i);
+        const removed = this.particleQueue.splice(0, i + 1);
         this.removeParticles(removed);
       }
     }

--- a/src/shapes/box.ts
+++ b/src/shapes/box.ts
@@ -1,9 +1,6 @@
 import * as THREE from 'three';
 import BaseShape from '.';
 
-/**
- * This is the most primitive shape
- */
 export default class Box extends BaseShape {
   constructor(width: number = 1, height: number = 1, depth: number = 1) {
     const shape = new THREE.BoxGeometry(width, height, depth, 1, 1);

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface IParticleOptions {
   maxParticleSize?: number;
   color?: color; // Hexadecimal RGB
   playOnLoad?: boolean;
+  duration?: number;
   loop?: boolean;
   shape?: IShape;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type vectorTuple = [THREE.Vector3, THREE.Vector3];
 export type color = number | string;
+export declare type particleTuple = [number, THREE.Mesh]; // [timestamp, theParticleMesh]
 
 export interface IShape {
   geometry: THREE.Geometry;


### PR DESCRIPTION
Features and changes:
- Particle Queue is now an array of tuples ([timestamp, mesh]), was just the mesh before
- Update the `update` and `createParticles` methods to handle the tuple.
- Added a cull based on time step to the `update` method
- Create a `removeParticles` method to abstract the removal of particles. Then, implemented when culling based on time and culling based on excess particles.
- Add a `duration` option. Defaults to 2000ms