### PR TITLE
Feature: World Position

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ The `ParticleSystem`'s constructor takes two arguments, the target object to att
 
 **Default**: PlaneShape
 
+
+
 # Disclaimer
 
 This project is still experimental. Do not use this in production!

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ The `ParticleSystem`'s constructor takes two arguments, the target object to att
 
 **Default**: true
 
+### duration
+
+**Description**: The duration of the particle effect in milliseconds. Note, this only describes how long particles are produced for. Particles alive after the duration has elapsed will live until they reach the end of their `particleLifetime`
+
+**Type**: number
+
+**Default**: 2000
+
 ### maxParticles
 
 **Description**: The maximum number of particles to be rendered.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ particles.stop();
 
 The `ParticleSystem`'s constructor takes two arguments, the target object to attach the particle system to and the options object. Below are all of the options you can provide.
 
+### target
+
+**Description**: The object to attach the particle system to. This Object3D must be added to the scene prior to declaring `new ParticleSystem(target)`
+
+**Type**: Object3D
+
+**Required**: true
+
 ### Color
 
 **Description**: The color of the particle in hexadecimal format.
@@ -129,6 +137,13 @@ The `ParticleSystem`'s constructor takes two arguments, the target object to att
 
 **Default**: PlaneShape
 
+### worldSpace
+
+**Description**: Place new particles in world space, regardless of the target's position. So, updated particles will move in relative space and not relative to the target.
+
+**Type**: boolean
+
+**Default**: false
 
 
 # Disclaimer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "three-particle-system",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-particle-system",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A particle effect system for Three.js",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,47 +7,48 @@ import { isBool } from './utils/typeCheck';
 
 export default class ParticleSystem implements IParticleSystem {
   color: color = 0xedaa67;
+  duration: number = 2000; // in MS
+  elapsedTime: number = 0;
+  globalPosition: boolean = true;
   initialRotationRange: vectorTuple = [
     // one of tuple of vec3<float> or vec3<float>. Values in radians
     new THREE.Vector3(0, 0, 0),
     new THREE.Vector3(Math.PI * 2, Math.PI * 2, Math.PI * 2),
   ];
-  loop: boolean = true;
-  maxParticles: number = 100;
-  particleLifetime: number = 2000; // in MS
-  particlesPerSecond: number = 50;
-  particleVelocity: number = 1; // units per second
-  rotationRate: number = 0; // in radians
-  radius: THREE.Vector3 = new THREE.Vector3(1, 1, 1);
-  minParticleSize: number = 0.1;
-  maxParticleSize: number = 0.1;
-  playOnLoad: boolean = true;
-  shape: IShape = new PlaneShape();
-  target: Object3D;
-
-  particleQueue: particleTuple[] = [];
-  duration: number = 2000; // in MS
   isPlaying: boolean = true;
-  elapsedTime: number = 0;
+  loop: boolean = true;
+  maxParticleSize: number = 0.1;
+  maxParticles: number = 100;
+  minParticleSize: number = 0.1;
+  particleLifetime: number = 2000; // in MS
+  particleQueue: particleTuple[] = [];
+  particleVelocity: number = 1; // units per second
+  particlesPerSecond: number = 50;
+  playOnLoad: boolean = true;
+  radius: THREE.Vector3 = new THREE.Vector3(1, 1, 1);
+  rotationRate: number = 0; // in radians
+  shape: IShape = new PlaneShape();
   startTime: number;
+  target: Object3D;
 
   constructor(target: Object3D, options: IParticleOptions) {
     // User Defined Values
     this.color = options.color || this.color;
-    this.initialRotationRange = options.initialRotationRange || this.initialRotationRange;
-    this.minParticleSize = options.minParticleSize || options.maxParticleSize || this.minParticleSize;
-    this.maxParticles = options.maxParticles || this.maxParticles;
-    this.maxParticleSize = options.maxParticleSize || options.minParticleSize || 0.1;
-    this.particleLifetime = options.particleLifetime || this.particleLifetime;
-    this.particlesPerSecond = options.particlesPerSecond || this.particlesPerSecond;
-    this.particleVelocity = options.particleVelocity || this.particleVelocity;
-    this.loop = isBool(options.loop) ? options.playOnLoad || false : this.loop;
     this.duration = options.duration || this.duration;
+    this.globalPosition = isBool(options.globalPosition) ? options.globalPosition || this.globalPosition;
+    this.initialRotationRange = options.initialRotationRange || this.initialRotationRange;
     this.isPlaying = isBool(options.playOnLoad) ? options.playOnLoad || false : this.isPlaying;
+    this.loop = isBool(options.loop) ? options.playOnLoad || false : this.loop;
+    this.maxParticleSize = options.maxParticleSize || options.minParticleSize || 0.1;
+    this.maxParticles = options.maxParticles || this.maxParticles;
+    this.minParticleSize = options.minParticleSize || options.maxParticleSize || this.minParticleSize;
+    this.particleLifetime = options.particleLifetime || this.particleLifetime;
+    this.particleVelocity = options.particleVelocity || this.particleVelocity;
+    this.particlesPerSecond = options.particlesPerSecond || this.particlesPerSecond;
     this.radius = options.radius || this.radius;
     this.rotationRate = options.rotationRate || this.rotationRate;
-    this.target = target;
     this.shape = options.shape || this.shape;
+    this.target = target;
 
     // Member Variables
     this.startTime = Date.now();

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ export default class ParticleSystem implements IParticleSystem {
   color: color = 0xedaa67;
   duration: number = 2000; // in MS
   elapsedTime: number = 0;
-  globalPosition: boolean = true;
   initialRotationRange: vectorTuple = [
     // one of tuple of vec3<float> or vec3<float>. Values in radians
     new THREE.Vector3(0, 0, 0),
@@ -30,12 +29,12 @@ export default class ParticleSystem implements IParticleSystem {
   shape: IShape = new PlaneShape();
   startTime: number;
   target: Object3D;
+  worldSpace: boolean = true;
 
   constructor(target: Object3D, options: IParticleOptions) {
     // User Defined Values
     this.color = options.color || this.color;
     this.duration = options.duration || this.duration;
-    this.globalPosition = isBool(options.globalPosition) ? options.globalPosition || this.globalPosition;
     this.initialRotationRange = options.initialRotationRange || this.initialRotationRange;
     this.isPlaying = isBool(options.playOnLoad) ? options.playOnLoad || false : this.isPlaying;
     this.loop = isBool(options.loop) ? options.playOnLoad || false : this.loop;
@@ -49,7 +48,8 @@ export default class ParticleSystem implements IParticleSystem {
     this.rotationRate = options.rotationRate || this.rotationRate;
     this.shape = options.shape || this.shape;
     this.target = target;
-
+    this.worldSpace = isBool(options.worldSpace) ? options.worldSpace || this.worldSpace;
+    
     // Member Variables
     this.startTime = Date.now();
   }
@@ -110,6 +110,7 @@ export default class ParticleSystem implements IParticleSystem {
 
     // update current particles
     this.particleQueue.forEach(([timestamp, mesh]: particleTuple) => {
+      mesh.getWorldPosition(mesh.position);
       mesh.position.y += this.particleVelocity * deltaTime;
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface IShape {
 }
 
 export interface IParticleOptions {
+  globalPosition?: boolean;
   initialRotationRange?: vectorTuple;
   maxParticles?: number;
   particleLifetime?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,6 @@ export interface IShape {
 }
 
 export interface IParticleOptions {
-  globalPosition?: boolean;
   initialRotationRange?: vectorTuple;
   maxParticles?: number;
   particleLifetime?: number;
@@ -28,6 +27,7 @@ export interface IParticleOptions {
   duration?: number;
   loop?: boolean;
   shape?: IShape;
+  worldSpace?: boolean;
 }
 
 export interface IParticleSystem extends IParticleOptions {


### PR DESCRIPTION
In this PR, I added the ability to have particles move in world space. Before, particles would always move relative to the target.

Particles will still spawn in on the target.